### PR TITLE
ELEC-98: Add Vagrantfile for uwmidsun/box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+### Vagrant ###
+.vagrant/
+
+
+### Vim ###
+# swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags
+
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### uw-midsun/box ###
+shared/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ In addition, the virtual machine will be setup to automatically passthrough a ST
 
 You may also need go into your BIOS to ensure that VT-x/AMD-v (also known as *Intel(R) Virtualization Technology*) settings are enabled.
 
+### Windows
+On Windows, you may want to add the folder where you installed VirtualBox to your ``$PATH``. You can follow the instructions [here](http://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/) to do so. This step is *optional*.
+
 ### macOS
 There's a [regression](https://www.virtualbox.org/ticket/15956) in VirtualBox that prevents USB passthrough from working correctly with STLink/JTag. On a Mac, ensure you install [VirtualBox 5.0.8](https://www.virtualbox.org/wiki/Download_Old_Builds_5_0_pre18) and the 5.0.8 Extension Pack.
 
@@ -44,7 +47,11 @@ These 3 steps only need to be run the first time you start working with ``uwmids
 
 **Note**: Ensure that when running these commands, the STLink and USB device is disconnected, otherwise the USB filter will not pass the USB device through to the VM. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
 
-The ``shared/`` directory will be shared between your host operating system and the virtual environmnent (``/home/vagrant/shared/``).
+The ``shared/`` directory will be shared between your host operating system and the virtual environment (``/home/vagrant/shared/``). You can clone the ``uw-midsun/firmware`` repository here from the ``ssh`` session, and then use your editor of choice from your host operating system
+
+```bash
+cd shared && git clone https://github.com/uw-midsun/firmware.git
+```
 
 ## Vagrant Commands
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ In addition, the virtual machine will be setup to automatically passthrough a ST
 * [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 
+## macOS
+There's a [regression](https://www.virtualbox.org/ticket/15956) in VirtualBox that prevents USB passthrough from working correctly with STLink/JTag. On a Mac, ensure you install [VirtualBox 5.0.8](https://www.virtualbox.org/wiki/Download_Old_Builds_5_0_pre18) and the 5.0.8 Extension Pack.
+
+### Linux
 On **Linux**, you'll also have to add your user to the ``vboxusers`` group, so that the virtual machine can access your USB devices. After installing all the above, run
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ In addition, the virtual machine will be setup to automatically passthrough a ST
 * [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 
-## macOS
+You may also need go into your BIOS to ensure that VT-x/AMD-v (also known as *Intel(R) Virtualization Technology*) settings are enabled.
+
+### macOS
 There's a [regression](https://www.virtualbox.org/ticket/15956) in VirtualBox that prevents USB passthrough from working correctly with STLink/JTag. On a Mac, ensure you install [VirtualBox 5.0.8](https://www.virtualbox.org/wiki/Download_Old_Builds_5_0_pre18) and the 5.0.8 Extension Pack.
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # box
-a preconfigured Vagrant box with a full GCC ARM toolchain for embedded development
+
+``uwmidsun/box`` is a preconfigured Vagrant box with a full GCC ARM toolchain for compiling ARM code and flashing and debugging it with tools like OpenOCD and gdb. Using this virtual environment, you can get set up to compile and load ARM code from any platform that Vagrant supports (Windows, Mac OSX, Linux).
+
+No provisioning tools or setup is really even required to use ``uwmidsun/box``. Since everything is packaged into the base box, running ``vagrant`` is super fast, you'll never have to worry about your environment breaking with updates, and you won't need the internet to code.
+
+The ARM toolchain that will be set up includes the following tools:
+
+* GCC ARM Embedded
+* OpenOCD
+
+In addition, the virtual machine will be setup to automatically passthrough a STLink V2 programmer for easy flashing of STM32 microcontrollers.
+
+## Requirements
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
+* [Vagrant](https://www.vagrantup.com/downloads.html)
+
+On **Linux**, you'll also have to add your user to the ``vboxusers`` group, so that the virtual machine can access your USB devices. After installing all the above, run
+
+```bash
+sudo usermod -a -G vboxusers $USER
+```
+
+Then reboot your machine.
+
+## Getting Started
+
+```bash
+git clone https://github.com/uw-midsun/box.git box && cd box
+vagrant up && vagrant reload
+vagrant ssh
+```
+
+These 3 steps only need to be run the first time you start working with ``uwmidsun/box``. Otherwise, you can just do ``vagrant up``, followed by ``vagrant ssh``.
+
+**Note**: Ensure that when running these commands, the STLink and USB device is disconnected. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
+
+The ``shared/`` directory will be shared between your host operating system and the virtual environmnent (``/home/vagrant/shared/``).
+
+## Vagrant Commands
+
+Open a terminal in the directory with the ``Vagrantfile`` and run these commands
+
+### Start or resume
+
+```bash
+vagrant up
+```
+
+### Connect to the box (ssh)
+
+```bash
+vagrant ssh
+```
+
+When you're ready to stop the VM, you can exit it by running the following command inside the VM:
+
+```bash
+exit
+```
+
+**Notes**: After you exit the VM, it will still be running! You can enter the VM again by sshing in again, or you can shutdown the VM by running
+
+```bash
+vagrant halt
+```
+
+### Delete box
+
+If you ever want to start fresh (which wipes everything)
+
+```bash
+vagrant destroy
+```
+
+## Updating the box
+
+Although not necessary, if you want to check for updates, just type
+
+```bash
+vagrant box outdated
+```
+
+It will tell you if you are running the latest version or not. If it says you aren't, simply run
+
+```bash
+vagrant box update
+```
+
+## Features
+
+This box comes with the following
+
+### System Stuff
+* Git
+* tmux
+* vim
+
+### C Stuff
+* build-essential
+* gdb
+
+### Ruby
+* rvm

--- a/README.md
+++ b/README.md
@@ -30,29 +30,34 @@ Then reboot your machine.
 
 ## Getting Started
 
+Disconnect the STLink and USB device. Then, run
+
 ```bash
 git clone https://github.com/uw-midsun/box.git box && cd box
 vagrant up && vagrant reload
 vagrant ssh
 ```
 
-These 3 steps only need to be run the first time you start working with ``uwmidsun/box``. Otherwise, you can just do ``vagrant up``, followed by ``vagrant ssh``.
+These 3 steps only need to be run the first time you start working with ``uwmidsun/box``. Otherwise, you can just do ``vagrant up`` from the ``box/`` directory, followed by ``vagrant ssh``.
 
-**Note**: Ensure that when running these commands, the STLink and USB device is disconnected. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
+**Note**: Ensure that when running these commands, the STLink and USB device is disconnected, otherwise the USB filter will not pass the USB device through to the VM. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
 
 The ``shared/`` directory will be shared between your host operating system and the virtual environmnent (``/home/vagrant/shared/``).
 
 ## Vagrant Commands
 
-Open a terminal in the directory with the ``Vagrantfile`` and run these commands
+Open a terminal in the directory with the ``Vagrantfile`` and run these commands. More details can be found in the [Vagrant documentation](https://www.vagrantup.com/docs/cli/).
 
 ### Start or resume
+To start or resume a box
 
 ```bash
 vagrant up
 ```
 
 ### Connect to the box (ssh)
+
+Once the box is up, you can ``ssh`` to the box by doing
 
 ```bash
 vagrant ssh
@@ -64,7 +69,7 @@ When you're ready to stop the VM, you can exit it by running the following comma
 exit
 ```
 
-**Notes**: After you exit the VM, it will still be running! You can enter the VM again by sshing in again, or you can shutdown the VM by running
+**Note**: After you exit the VM, it will still be running! You can enter the VM again by sshing in again, or you can shutdown the VM by running
 
 ```bash
 vagrant halt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # VirtualBox configuration
   config.vm.provider "virtualbox" do |vb|
+    # Fix for VirtualBox 5.1 regression (for macOS)
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+
     # Turn on USB 2.0 support
     vb.customize ['modifyvm', :id, '--usb', 'on']
     vb.customize ['modifyvm', :id, '--usbehci', 'on']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,9 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+require_relative 'lib/better_usb.rb'
+require_relative 'lib/which.rb'
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "uwmidsun/box"
   config.vm.synced_folder "shared", "/home/vagrant/shared", :mount_options => ["dmode=777", "fmode=666"]
@@ -26,11 +29,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     #   https://www.virtualbox.org/wiki/Downloads
     # On Linux, add your user to the vboxusers group
     #   sudo usermod -a -G vboxusers $USER
-    vb.customize ['usbfilter', 'add', '0',
-                  '--target', :id,
-                  '--name', 'STLink',
-                  '--vendorid', '0483',
-                  '--productid', '3748']
+    if not Which.which('VBoxManage').nil?
+      BetterUSB.usbfilter_add(vb, '0483', '3748', 'STLink')
+    else
+      vb.customize ["usbfilter", "add", "0",
+                    "--target", :id,
+                    "--name", "STLink",
+                    "--vendorid", "0483",
+                    "--productid", "3748"
+      ]
+    end
 
     # Customize the amount of memory on the VM:
     # vb.memory = "1024"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,36 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. Please don't change it unless you know what you're doing.
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "uwmidsun/box"
+  config.vm.synced_folder "shared", "/home/vagrant/shared", :mount_options => ["dmode=777", "fmode=666"]
+
+  # Optional NFS. Make sure to remove other synced_folder line too
+  # config.vm.synced_folder "shared", "/home/vagrant/shared", :nfs => { :mount_options => ["dmode=777","fmode=666"] }
+
+  # VirtualBox configuration
+  config.vm.provider "virtualbox" do |vb|
+    # Turn on USB 2.0 support
+    vb.customize ['modifyvm', :id, '--usb', 'on']
+    vb.customize ['modifyvm', :id, '--usbehci', 'on']
+
+    # Add USB filter to attach STLink programmer
+    # The VirtualBox extension pack MUST be installed first
+    #   https://www.virtualbox.org/wiki/Downloads
+    # On Linux, add your user to the vboxusers group
+    #   sudo usermod -a -G vboxusers $USER
+    vb.customize ['usbfilter', 'add', '0',
+                  '--target', :id,
+                  '--name', 'STLink',
+                  '--vendorid', '0483',
+                  '--productid', '3748']
+
+    # Customize the amount of memory on the VM:
+    # vb.memory = "1024"
+  end
+
+end

--- a/lib/better_usb.rb
+++ b/lib/better_usb.rb
@@ -1,0 +1,30 @@
+module BetterUSB
+
+  def self.usbfilter_exists(vendor_id, product_id)
+    machine_id_filepath = File.join(".vagrant", "machines", "default", "virtualbox", "id")
+
+    if not File.exists? machine_id_filepath
+      # VM hasn't been created yet
+      return false
+    end
+
+    machine_id = File.read(machine_id_filepath)
+
+    vm_info = `VBoxManage showvminfo #{machine_id}`
+    filter_match = "VendorId:         #{vendor_id}\nProductId:        #{product_id}\n"
+
+    vm_info.include? filter_match
+  end
+
+  def self.usbfilter_add(vb, vendor_id, product_id, filter_name)
+    unless usbfilter_exists(vendor_id, product_id)
+      vb.customize ["usbfilter", "add", "0",
+                    "--target", :id,
+                    "--name", filter_name,
+                    "--vendorid", vendor_id,
+                    "--productid", product_id
+                   ]
+    end
+  end
+
+end

--- a/lib/which.rb
+++ b/lib/which.rb
@@ -1,0 +1,57 @@
+module Which
+
+  # which returns the pathnames of the files (or links) which would be
+  # executed in the current environment, had its arguments been given as
+  # commands in the shell by searching in the $PATH
+  def self.which(cmd)
+    w = Which.new
+    w.which0(cmd) do |abs_exe|
+      return abs_exe
+    end
+    nil
+  end
+
+  # which_all returns all matching pathnames of the files that are in the $PATH
+  # similar to which -a
+  def self.which_all(cmd)
+    w = Which.new
+    results = []
+    w.which0(cmd) do |abs_exe|
+      results << abs_exe
+    end
+    results
+  end
+
+  class Which
+    def executable_program?(file)
+      # directories can be executable, so we exclude them
+      File.executable?(file) && !File.directory?(file)
+    end
+
+    def find_executables(path, cmd, &_block)
+      executable_path_extensions.each do |ext|
+        if executable_program?(abs_path = File.expand_path(cmd + ext, path))
+          yield(abs_path)
+        end
+      end
+    end
+
+    def executable_path_extensions
+      # $PATHEXT is used on Windows to determine valid file extensions
+      ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+    end
+
+    def search_paths
+      ENV['PATH'].split(File::PATH_SEPARATOR)
+    end
+
+    def which0(cmd, &found_exe)
+      find_executables(nil, cmd, &found_exe) if File.basename(cmd) != cmd
+
+      search_paths.each do |path|
+        find_executables(path, cmd, &found_exe)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
So I think I've finally managed to figure out the reason why USB passthrough on macOS was failing. There's actually a [regression in VirtualBox](https://www.virtualbox.org/ticket/15956) that causes the STLink programmer to not show up. This afternoon, I downgraded to **VirtualBox 5.0.8**, and then installed the appropriate Extension Pack on my MacBook, and it seems to work. I've added that to the installation instructions in the ``README.md``.

There's also currently an issue with ``vb.customize``, where it will add a new ``usbfilter`` whenever ``vagrant up`` or ``vagrant reload`` is run. I can fix this with some Ruby (since the ``Vagrantfile`` is just Ruby) that checks whether the ``usbfilter`` already exists, but I'm not sure whether it'll be portable enough to handle different permutations of where ``VBoxManage`` is located on Windows (like, is it always available on the ``PATH``?).

I've tested this on macOS and Ubuntu 16.04 LTS.

I won't merge this until we upload the box to Atlas (or somewhere else), but this is just for a preliminary review. In the meantime, you'd just have to do ``vagrant box add uwmidsun/box /path/to/vagrant-box.box``