### PR TITLE
ELEC-106: Update VirtualBox requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You may also need go into your BIOS to ensure that VT-x/AMD-v (also known as *In
 On Windows, you may want to add the folder where you installed VirtualBox to your ``$PATH``. You can follow the instructions [here](http://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/) to do so. This step is *optional*.
 
 ### macOS
-There's a [regression](https://www.virtualbox.org/ticket/15956) in VirtualBox that prevents USB passthrough from working correctly with STLink/JTag. On a Mac, ensure you install [VirtualBox 5.0.8](https://www.virtualbox.org/wiki/Download_Old_Builds_5_0_pre18) and the 5.0.8 Extension Pack.
+Ensure you're using the latest version of VirtualBox (VirtualBox 5.1.16 or later). There was a [regression](https://www.virtualbox.org/ticket/15956) in VirtualBox that prevented USB passthrough from working correctly with STLink/JTag that was fixed in VirtualBox 5.1.16.
 
 ### Linux
 On **Linux**, you'll also have to add your user to the ``vboxusers`` group, so that the virtual machine can access your USB devices. After installing all the above, run

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,10 +10,15 @@ require_relative 'lib/which.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "uwmidsun/box"
-  config.vm.synced_folder "shared", "/home/vagrant/shared", :mount_options => ["dmode=777", "fmode=666"]
+
+  config.vm.network "private_network", ip: "192.168.24.24"
+  config.vm.hostname = "midsunbox"
+
+  # Default synced_folder mount. Remove this line if using NFS
+  config.vm.synced_folder "shared", "/home/vagrant/shared", :mount_options => ["dmode=777", "fmode=777"]
 
   # Optional NFS. Make sure to remove other synced_folder line too
-  # config.vm.synced_folder "shared", "/home/vagrant/shared", :nfs => { :mount_options => ["dmode=777","fmode=666"] }
+  # config.vm.synced_folder "shared", "/home/vagrant/shared", :nfs => true
 
   # VirtualBox configuration
   config.vm.provider "virtualbox" do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,9 +17,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # VirtualBox configuration
   config.vm.provider "virtualbox" do |vb|
-    # Fix for VirtualBox 5.1 regression (for macOS)
-    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
-
     # Turn on USB 2.0 support
     vb.customize ['modifyvm', :id, '--usb', 'on']
     vb.customize ['modifyvm', :id, '--usbehci', 'on']


### PR DESCRIPTION
Update the VirtualBox requirement for macOS, since the [VirtualBox ticket](https://www.virtualbox.org/ticket/15956) has now been resolved.

Also, updated the ``Vagrantfile`` so that built binaries can be run.