### PR TITLE
ELEC-258: Improve virtual machine id detection

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,25 +3,24 @@
 
 # All Vagrant configuration is done below. Please don't change it unless you know what you're doing.
 
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = '2'
 
 require_relative 'lib/better_usb.rb'
-require_relative 'lib/which.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "uwmidsun/box"
+  config.vm.box = 'uwmidsun/box'
 
-  config.vm.network "private_network", ip: "192.168.24.24"
-  config.vm.hostname = "midsunbox"
+  config.vm.network 'private_network', ip: '192.168.24.24'
+  config.vm.hostname = 'midsunbox'
 
   # Default synced_folder mount. Remove this line if using NFS
-  config.vm.synced_folder "shared", "/home/vagrant/shared", :mount_options => ["dmode=777", "fmode=777"]
+  config.vm.synced_folder 'shared', '/home/vagrant/shared', :mount_options => ["dmode=777", "fmode=777"]
 
   # Optional NFS. Make sure to remove other synced_folder line too
   # config.vm.synced_folder "shared", "/home/vagrant/shared", :nfs => true
 
   # VirtualBox configuration
-  config.vm.provider "virtualbox" do |vb|
+  config.vm.provider 'virtualbox' do |vb|
     # Turn on USB 2.0 support
     vb.customize ['modifyvm', :id, '--usb', 'on']
     vb.customize ['modifyvm', :id, '--usbehci', 'on']
@@ -31,23 +30,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     #   https://www.virtualbox.org/wiki/Downloads
     # On Linux, add your user to the vboxusers group
     #   sudo usermod -a -G vboxusers $USER
-    if not Which.which('VBoxManage').nil?
-      BetterUSB.usbfilter_add(vb, '0483', '3748', 'STLink')
-      BetterUSB.usbfilter_add(vb, '1209', 'da42', 'CMSIS-DAP')
-    else
-      vb.customize ["usbfilter", "add", "0",
-                    "--target", :id,
-                    "--name", "STLink",
-                    "--vendorid", "0483",
-                    "--productid", "3748"
-      ]
-      vb.customize ["usbfilter", "add", "1",
-                    "--target", :id,
-                    "--name", "CMSIS-DAP",
-                    "--vendorid", "1209",
-                    "--productid", "da42"
-      ]
-    end
+    BetterUSB.usbfilter_add(vb, '0483', '3748', 'STLink')
+    BetterUSB.usbfilter_add(vb, '1209', 'da42', 'CMSIS-DAP')
 
     # Customize the amount of memory on the VM:
     # vb.memory = "1024"

--- a/lib/better_usb.rb
+++ b/lib/better_usb.rb
@@ -1,7 +1,11 @@
 module BetterUSB
 
+  require_relative 'which.rb'
+
   def self.usbfilter_exists(vendor_id, product_id)
-    machine_id_filepath = File.join(".vagrant", "machines", "default", "virtualbox", "id")
+    # .vagrant/ is located in the same directory as the Vagrantfile
+    # Vagrantfile is in the parent dir relative to ./lib/better_usb.rb
+    machine_id_filepath = File.join(File.expand_path(File.dirname(__FILE__)), '..', '.vagrant', 'machines', 'default', 'virtualbox', 'id')
 
     if not File.exists? machine_id_filepath
       # VM hasn't been created yet
@@ -17,12 +21,12 @@ module BetterUSB
   end
 
   def self.usbfilter_add(vb, vendor_id, product_id, filter_name)
-    unless usbfilter_exists(vendor_id, product_id)
-      vb.customize ["usbfilter", "add", "0",
-                    "--target", :id,
-                    "--name", filter_name,
-                    "--vendorid", vendor_id,
-                    "--productid", product_id
+    if Which.which('VBoxManage').nil? || !usbfilter_exists(vendor_id, product_id)
+      vb.customize ['usbfilter', 'add', '0',
+                    '--target', :id,
+                    '--name', filter_name,
+                    '--vendorid', vendor_id,
+                    '--productid', product_id
                    ]
     end
   end


### PR DESCRIPTION
Sample test case

```bash
git clone https://github.com/uw-midsun/box && cd box/
vagrant up
vagrant reload # USB filter should be added
vagrant reload # no duplicate USB filter should be added

cd shared/
vagrant reload # no duplicate USB filter should be added
cd firmware/ # assuming firmware has been cloned to ./box/shared/firmware
vagrant reload # no duplicate USB filter should be added
```