### PR TITLE
Changed README file for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ These 3 steps only need to be run the first time you start working with ``uwmids
 
 **Note**: Ensure that when running these commands, the STLink and USB device is disconnected, otherwise the USB filter will not pass the USB device through to the VM. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
 
-The ``shared/`` directory will be shared between your host operating system and the virtual environment (``/home/vagrant/shared/``). You can clone the ``uw-midsun/firmware`` repository here from the ``ssh`` session, and then use your editor of choice from your host operating system
+The ``shared/`` directory in the virtual box will be shared between your host operating system and the virtual environment. The location in your operating system is: (``/<where-you-cloned-this-repo>/shared/``). You can clone the ``uw-midsun/firmware`` repository here from the ``ssh`` session, and then use your editor of choice from your host operating system
 
 ```bash
 cd shared && git clone https://github.com/uw-midsun/firmware.git

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ These 3 steps only need to be run the first time you start working with ``uwmids
 
 **Note**: Ensure that when running these commands, the STLink and USB device is disconnected, otherwise the USB filter will not pass the USB device through to the VM. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
 
-The ``shared/`` directory in the virtual box will be shared between your host operating system and the virtual environment. The location in your operating system is: (``/<where-you-cloned-this-repo>/shared/``). You can clone the ``uw-midsun/firmware`` repository here from the ``ssh`` session, and then use your editor of choice from your host operating system
+The ``shared/`` directory in the vagrant box will be shared between your host operating system and the virtual environment. The location in your operating system is: (``/<where-you-cloned-this-repo>/shared/``). You can clone the ``uw-midsun/firmware`` repository here from the ``ssh`` session, and then use your editor of choice from your host operating system
 
 ```bash
 cd shared && git clone https://github.com/uw-midsun/firmware.git


### PR DESCRIPTION
When I was setting up vagrant, I wanted to look for the /shared directory. The current documentation says it's at /home/vagrant/shared, but it's actually at /path-to-box-repo/shared. So I changed it. :) 