### PR TITLE
ELEC-559: Add VirtualBox USB filter for Digi XBee

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     BetterUSB.usbfilter_add(vb, '0403', '6001', 'FTDI TTL232R-3V3')
     BetterUSB.usbfilter_add(vb, '0483', '3748', 'STLink')
 
+    # Digi XBee
+    BetterUSB.usbfilter_add(vb, '0403', '6015', 'Digi XBee')
+
     # Customize the amount of memory on the VM:
     # vb.memory = "1024"
   end


### PR DESCRIPTION
Add a VirtualBox USB filter for the Digi XBee that we used at FSGP/ASC
2018 for telemetry. This is so we don't need to open up VirtualBox and
manually pass through if we want to use it.

The `udev` rule is the second half of this change, and needs to be 
made against the `packer` repo.

Totally untested, since I don't have the XBee on me. But if someone 
wants to validate this for me, that'd be :ok_hand: