### PR TITLE
ELEC-600: Add USB filter for PEAK System PCAN-USB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,6 +37,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Digi XBee
     BetterUSB.usbfilter_add(vb, '0403', '6015', 'Digi XBee')
 
+    # PEAK System PCAN-USB dongle
+    BetterUSB.usbfilter_add(vb, '0c72', '0012', 'PEAK System PCAN-USB')
+
     # Customize the amount of memory on the VM:
     # vb.memory = "1024"
   end


### PR DESCRIPTION

```
 → TITANIC@box (master) $ lsusb | grep 'PEAK'
Bus 002 Device 006: ID 0c72:0012 PEAK System
```

```
 → TITANIC@firmware (master) $ vagrant ssh
Welcome to Ubuntu 18.04 LTS (GNU/Linux 4.15.0-20-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

 System information disabled due to load higher than 1.0

 * Ubuntu's Kubernetes 1.14 distributions can bypass Docker and use containerd
   directly, see https://bit.ly/ubuntu-containerd or try it now with

     snap install microk8s --channel=1.14/beta --classic

 * Canonical Livepatch is available for installation.
   - Reduce system reboots and improve kernel security. Activate at:
     https://ubuntu.com/livepatch

268 packages can be updated.
109 updates are security updates.


Last login: Wed Mar 27 04:22:48 2019 from 10.0.2.2
vagrant@midsunbox:~$ lsusb | grep 'PEAK'
Bus 001 Device 002: ID 0c72:0012 PEAK System
vagrant@midsunbox:~$ lsmod | grep -B 10 -A 10 'peak'
Module                  Size  Used by
peak_usb               40960  0
can_dev                28672  1 peak_usb
vboxsf                 45056  2
intel_powerclamp       16384  0
intel_rapl_perf        16384  0
snd_intel8x0           40960  0
snd_ac97_codec        131072  1 snd_intel8x0
ac97_bus               16384  1 snd_ac97_codec
snd_pcm                98304  2 snd_ac97_codec,snd_intel8x0
snd_timer              32768  1 snd_pcm
input_leds             16384  0
vboxvideo              36864  1
vagrant@midsunbox:~$ sudo modprobe can && sudo modprobe can_raw && sudo modprobe vcan
vagrant@midsunbox:~$ sudo ip link set can0 up type can bitrate 500000
vagrant@midsunbox:~$ candump can0
  can0  421   [8]  11 11 11 11 C0 1D FE FF
  can0  421   [8]  11 11 11 11 C0 1D FE FF
  can0  421   [8]  11 11 11 11 C0 1D FE FF
  can0  421   [8]  11 11 11 11 C0 1D FE FF
  can0  421   [8]  11 11 11 11 C0 1D FE FF
```
