### PR TITLE
added port forwarding of 8000 for django development

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'uwmidsun/box'
 
   config.vm.network 'private_network', ip: '192.168.24.24'
+  # For Django development on CAN-Explorer project
+  config.vm.network :forwarded_port, host: 8000, guest: 8000
   config.vm.hostname = 'midsunbox'
 
   # Default synced_folder mount. Remove this line if using NFS


### PR DESCRIPTION
We could technically use port 2222. My only worry was that another project was already using it. If not, we could switch over to that port for the CAN-Explorer Django app.