### PR TITLE
Updated Vagrantfile including port 3000

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'uwmidsun/box'
 
   config.vm.network 'private_network', ip: '192.168.24.24'
+  
   # For Django development on CAN-Explorer project
   config.vm.network :forwarded_port, host: 8000, guest: 8000
+  config.vm.network :forwarded_port, host: 3000, guest: 3000
+  
   config.vm.hostname = 'midsunbox'
 
   # Default synced_folder mount. Remove this line if using NFS


### PR DESCRIPTION
CAN explorer's front end react app uses port 3000, so we'd like that port forwarded as well.