### PR TITLE
ubuntu 20.04 box

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # box
 
-``uwmidsun/box`` is a preconfigured Vagrant box with a full GCC ARM toolchain for compiling ARM code and flashing and debugging it with tools like OpenOCD and gdb. Using this virtual environment, you can get set up to compile and load ARM code from any platform that Vagrant supports (Windows, Mac OSX, Linux).
+``backpack.box`` is a preconfigured Vagrant box with a full GCC ARM toolchain for compiling ARM code and flashing and debugging it with tools like OpenOCD and gdb. Using this virtual environment, you can get set up to compile and load ARM code from any platform that Vagrant supports (Windows, Mac OSX, Linux).
 
-No provisioning tools or setup is really even required to use ``uwmidsun/box``. Since everything is packaged into the base box, running ``vagrant`` is super fast, you'll never have to worry about your environment breaking with updates, and you won't need the internet to code.
+No provisioning tools or setup is really even required to use ``backpack.box``. Since everything is packaged into the base box, running ``vagrant`` is super fast, you'll never have to worry about your environment breaking with updates, and you won't need the internet to code.
 
 The ARM toolchain that will be set up includes the following tools:
 
@@ -43,7 +43,7 @@ vagrant up && vagrant reload
 vagrant ssh
 ```
 
-These 3 steps only need to be run the first time you start working with ``uwmidsun/box``. Otherwise, you can just do ``vagrant up`` from the ``box/`` directory, followed by ``vagrant ssh``.
+These 3 steps only need to be run the first time you start working with ``backpack.box``. Otherwise, you can just do ``vagrant up`` from the ``box/`` directory, followed by ``vagrant ssh``.
 
 **Note**: Ensure that when running these commands, the STLink and USB device is disconnected, otherwise the USB filter will not pass the USB device through to the VM. The ``vagrant reload`` is necessary to ensure USB passthrough is enabled.
 
@@ -94,17 +94,15 @@ vagrant destroy
 
 ## Updating the box
 
-Although not necessary, if you want to check for updates, just type
+To update the box from older ``umidsun/box`` run the following commands outside of vagrant environment
 
 ```bash
-vagrant box outdated
+vagrant halt
+vagrant destroy
+vagrant up
 ```
 
-It will tell you if you are running the latest version or not. If it says you aren't, simply run
-
-```bash
-vagrant box update
-```
+make you ubuntu welcomes you as Ubuntu-20.04, if not, it means vagrant is still launching a cached version of your old box. Make sure to remove all trace of the original ``umidsun/box``.
 
 ## Features
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ require_relative 'lib/better_usb.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'backpack.box'
-  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v0.2/backpack.box'
+  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v0.3/backpack.box'
 
   config.vm.network 'private_network', ip: '192.168.24.24'
   

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ require_relative 'lib/better_usb.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'backpack.box'
-  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v0.3/backpack.box'
+  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v1.0/backpack.box'
 
   config.vm.network 'private_network', ip: '192.168.24.24'
   

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ require_relative 'lib/better_usb.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'backpack.box'
-  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v1.0/backpack.box'
+  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v0.3/backpack.box'
 
   config.vm.network 'private_network', ip: '192.168.24.24'
   

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Turn on USB 2.0 support
     vb.customize ['modifyvm', :id, '--usb', 'on']
     vb.customize ['modifyvm', :id, '--usbehci', 'on']
+    vb.customize ['modifyvm', :id, '--usbxhci', 'on']
+    
 
     # Add USB filter to attach STLink programmer
     # The VirtualBox extension pack MUST be installed first

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,14 +8,15 @@ VAGRANTFILE_API_VERSION = '2'
 require_relative 'lib/better_usb.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'uwmidsun/box'
+  config.vm.box = 'backpack.box'
+  config.vm.box_url = 'https://github.com/uw-midsun/backpack/releases/download/v0.2/backpack.box'
 
   config.vm.network 'private_network', ip: '192.168.24.24'
   
   # For Django development on CAN-Explorer project
-  config.vm.network :forwarded_port, host: 8000, guest: 8000
-  config.vm.network :forwarded_port, host: 3000, guest: 3000
-  config.vm.network :forwarded_port, host: 8086, guest: 8086
+  # config.vm.network :forwarded_port, host: 8000, guest: 8000
+  # config.vm.network :forwarded_port, host: 3000, guest: 3000
+  # config.vm.network :forwarded_port, host: 8086, guest: 8086
   
   config.vm.hostname = 'midsunbox'
 


### PR DESCRIPTION
include scons + firmware_xiv tools

gcc 6 -> 8
arm-gcc 6 -> 8
clang 5 -> 10
clang-format 5 -> 10

I don't think we ever use clang so just upgraded that since 5 doesn't exist in 20.04
clang-format 5 is a bit different from 10, mostly #include order and format as well as initializers ending with a comma vs not.